### PR TITLE
Implement include/exclude options

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,15 @@ import laravelTranslations from 'vite-plugin-laravel-translations';
 export default defineConfig({
 	...
 	plugins: [
-		laravelTranslations({
-			// # TBC: To include JSON files
-			includeJson: false,
-			// # Declare: namespace (string|false)
-			namespace: false,
-		}),
+                laravelTranslations({
+                        // # TBC: To include JSON files
+                        includeJson: false,
+                        // # Declare: namespace (string|false)
+                        namespace: false,
+                        // # Optional: include or exclude specific language files
+                        // include: "server,errors",
+                        // exclude: "server,errors,local",
+                }),
 	],
 });
 ```
@@ -198,6 +201,18 @@ plugins: [
         absoluteLanguageDirectory: 'custom/path/to/lang',
     }),
 ],
+```
+
+## Including or excluding language files
+
+Use `include` or `exclude` to control which translation files are loaded. These options accept an array or comma separated list of patterns (regex allowed). Only one of them can be used at a time.
+
+```js
+plugins: [
+    laravelTranslations({
+        include: ['server'], // or exclude: 'server,errors,local'
+    }),
+]
 ```
 
 ## Asserting JSON Imports

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -11,6 +11,22 @@ import { mergeDeep } from "./utils/mergeDeep";
 import { TranslationConfiguration, InterpolationConfiguration, TranslationContentInterpolable } from "../types/index";
 
 /**
+ * Normalise include/exclude patterns to regular expressions
+ *
+ * @param pattern - Pattern string or array
+ * @returns RegExp[]
+ */
+const normalisePatterns = (pattern?: string | string[]): RegExp[] => {
+  if (!pattern) return [];
+  const patterns = Array.isArray(pattern) ? pattern : pattern.split(',');
+  return patterns
+    .map((p) => p.trim())
+    .filter(Boolean)
+    .map((p) => p.replace(/\.(php|json)$/i, ""))
+    .map((p) => new RegExp(p));
+};
+
+/**
  * Get the glob pattern based on the configuration
  *
  * @param shouldIncludeJson - Should include JSON files
@@ -90,7 +106,26 @@ export const buildTranslations = async (absLangPath: string, pluginConfiguration
   const globRegex = globPattern(pluginConfiguration.includeJson || false);
 
   // Fetch filenames as an array
-  const files = globSync(join(langDir, globRegex));
+  let files = globSync(join(langDir, globRegex));
+
+  const includePatterns = normalisePatterns(pluginConfiguration.include);
+  const excludePatterns = normalisePatterns(pluginConfiguration.exclude);
+
+  files = files.filter((file) => {
+    const pathSeparator = sep;
+    const fileRaw = file.replace(langDir + pathSeparator, "");
+    const relative = fileRaw.replace(extname(fileRaw), "").split(pathSeparator).join("/");
+
+    if (includePatterns.length) {
+      return includePatterns.some((regex) => regex.test(relative));
+    }
+
+    if (excludePatterns.length) {
+      return !excludePatterns.some((regex) => regex.test(relative));
+    }
+
+    return true;
+  });
 
   // Define initial translations
   const initialTranslations = Promise.resolve({});

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -21,6 +21,8 @@ export default async function laravelTranslations(pluginConfiguration: Translati
     assertJsonImport: false,
     absoluteLanguageDirectory: null,
     useGlobalVar: false,
+    include: undefined,
+    exclude: undefined,
   };
 
   // # Retrieve: Laravel Path (Absolute)
@@ -34,6 +36,10 @@ export default async function laravelTranslations(pluginConfiguration: Translati
     async config() {
       // # Merge: Configrations
       pluginConfiguration = Object.assign({}, defaultConfigurations, pluginConfiguration);
+
+      if (pluginConfiguration.include && pluginConfiguration.exclude) {
+        throw new Error('"include" and "exclude" options are mutually exclusive');
+      }
 
       // # Assign: Translations as LARAVEL_TRANSLATIONS/import.meta.env.VITE_LARAVEL_TRANSLATIONS
       const translationsVar = pluginConfiguration.useGlobalVar ? "LARAVEL_TRANSLATIONS" : "import.meta.env.VITE_LARAVEL_TRANSLATIONS";

--- a/tests/fixtures/translations-filter/errors.php
+++ b/tests/fixtures/translations-filter/errors.php
@@ -1,0 +1,4 @@
+<?php
+return [
+    'only-errors' => 'only-errors',
+];

--- a/tests/fixtures/translations-filter/local.php
+++ b/tests/fixtures/translations-filter/local.php
@@ -1,0 +1,4 @@
+<?php
+return [
+    'only-local' => 'only-local',
+];

--- a/tests/fixtures/translations-filter/server.php
+++ b/tests/fixtures/translations-filter/server.php
@@ -1,0 +1,4 @@
+<?php
+return [
+    'only-server' => 'only-server',
+];

--- a/tests/fixtures/translations-filter/server/emails.php
+++ b/tests/fixtures/translations-filter/server/emails.php
@@ -1,0 +1,4 @@
+<?php
+return [
+    'email' => 'server-email',
+];

--- a/tests/fixtures/translations-filter/translations-for-build-test-php.php
+++ b/tests/fixtures/translations-filter/translations-for-build-test-php.php
@@ -1,0 +1,5 @@
+<?php
+return [
+    'php-key' => 'php',
+    'key-from-php' => 'value-from-php',
+];

--- a/tests/fixtures/translations-filter/translations.php
+++ b/tests/fixtures/translations-filter/translations.php
@@ -1,0 +1,5 @@
+<?php
+return [
+    'key1' => 'value1',
+    'key2' => 'value2',
+];

--- a/tests/loader.test.ts
+++ b/tests/loader.test.ts
@@ -204,4 +204,54 @@ describe("Loader feature", () => {
       expect(translations).toEqual(expectedTranslations);
     });
   });
+
+  describe("buildTranslations function with exclude", () => {
+    it("should exclude matched translation files", async () => {
+      // Given
+      const absLangPath = "tests/fixtures/translations-filter";
+      const pluginConfiguration = {
+        exclude: "server,errors,local",
+      };
+      const expectedTranslations = {
+        translations: {
+          key1: "value1",
+          key2: "value2",
+        },
+        "translations-for-build-test-php": {
+          "php-key": "php",
+          "key-from-php": "value-from-php",
+        },
+      };
+
+      // When
+      const translations = await buildTranslations(absLangPath, pluginConfiguration);
+
+      // Then
+      expect(translations).toEqual(expectedTranslations);
+    });
+  });
+
+  describe("buildTranslations function with include", () => {
+    it("should include only matched translation files", async () => {
+      // Given
+      const absLangPath = "tests/fixtures/translations-filter";
+      const pluginConfiguration = {
+        include: "server",
+      };
+      const expectedTranslations = {
+        server: {
+          "only-server": "only-server",
+          emails: {
+            email: "server-email",
+          },
+        },
+      };
+
+      // When
+      const translations = await buildTranslations(absLangPath, pluginConfiguration);
+
+      // Then
+      expect(translations).toEqual(expectedTranslations);
+    });
+  });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -11,6 +11,8 @@ export declare interface TranslationConfiguration {
   absoluteLanguageDirectory?: string | null; // Optional param to override default langDir if needed
   interpolation?: InterpolationConfiguration | null;
   useGlobalVar?: boolean; // Compatibility mode for older versions - v1.x.x uses import.meta.env.VITE_LARAVEL_TRANSLATIONS
+  include?: string | string[];
+  exclude?: string | string[];
 }
 
 export declare interface InterpolationConfiguration {


### PR DESCRIPTION
## Summary
- add include/exclude config options to filter translations
- implement filtering logic in loader
- add mutually-exclusive check in plugin setup
- document include/exclude usage in README
- test include/exclude behaviour
- add new translation fixture files for tests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c9e11bfdc832a8b382b0113e1423e