### PR TITLE
feat: add workflow to build dist on for-hoistway

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -1,0 +1,47 @@
+name: Build dist assets
+
+on:
+  push:
+    branches:
+      - for-hoistway
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ vars.PNPM_VERSION || 10 }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build dist folder
+        run: pnpm run build
+
+      - name: Commit built assets
+        run: |
+          if [ -n "$(git status --porcelain dist)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add -f dist
+            git commit -m "chore: build dist" || echo "No changes to commit"
+            git push
+          else
+            echo "No changes to dist; skipping commit"
+          fi


### PR DESCRIPTION
## Summary
- build and commit `dist` assets on push to `for-hoistway` branch

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden fetching package)*

------
https://chatgpt.com/codex/tasks/task_e_68a8dbfdd194832a8f8a974cfee46d08