### PR TITLE
Use yarn in dist build workflow

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -1,0 +1,46 @@
+name: Build dist assets
+
+on:
+  push:
+    branches:
+      - for-hoistway
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+
+      - name: Enable Corepack
+        run: |
+          corepack enable
+          corepack prepare yarn@4.9.3 --activate
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build dist folder
+        run: yarn build
+
+      - name: Commit built assets
+        run: |
+          if [ -n "$(git status --porcelain dist)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add -f dist
+            git commit -m "chore: build dist" || echo "No changes to commit"
+            git push
+          else
+            echo "No changes to dist; skipping commit"
+          fi


### PR DESCRIPTION
## Summary
- ensure Corepack installs Yarn 4.9.3 in dist build workflow
- remove setup-node Yarn cache to avoid loading Yarn 1.x

## Testing
- `yarn test` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_68a8dbfdd194832a8f8a974cfee46d08